### PR TITLE
Add adjustable edges and theme prop

### DIFF
--- a/src/components/edges/AdjustableEdge.jsx
+++ b/src/components/edges/AdjustableEdge.jsx
@@ -1,0 +1,64 @@
+import React, { useCallback } from 'react';
+import { BaseEdge, EdgeLabelRenderer, getSmoothStepPath, useReactFlow } from 'reactflow';
+
+const AdjustableEdge = ({ id, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, style = {}, markerEnd, data }) => {
+    const { project, setEdges } = useReactFlow();
+
+    const control = data?.control || {
+        x: (sourceX + targetX) / 2,
+        y: (sourceY + targetY) / 2,
+    };
+
+    const [edgePath] = getSmoothStepPath({
+        sourceX,
+        sourceY,
+        sourcePosition,
+        targetX,
+        targetY,
+        targetPosition,
+        offset: 50,
+    });
+
+    const path = `M ${sourceX},${sourceY} Q ${control.x},${control.y} ${targetX},${targetY}`;
+
+    const updateControl = useCallback((event) => {
+        const flowBounds = document.querySelector('.react-flow');
+        if (!flowBounds) return;
+        const position = project({
+            x: event.clientX - flowBounds.getBoundingClientRect().left,
+            y: event.clientY - flowBounds.getBoundingClientRect().top,
+        });
+        setEdges((eds) =>
+            eds.map((e) => (e.id === id ? { ...e, data: { ...e.data, control: position } } : e))
+        );
+    }, [id, project, setEdges]);
+
+    const onMouseDown = useCallback((event) => {
+        event.stopPropagation();
+        event.preventDefault();
+        const onMouseMove = (e) => updateControl(e);
+        const onMouseUp = () => {
+            window.removeEventListener('mousemove', onMouseMove);
+            window.removeEventListener('mouseup', onMouseUp);
+        };
+        window.addEventListener('mousemove', onMouseMove);
+        window.addEventListener('mouseup', onMouseUp);
+    }, [updateControl]);
+
+    return (
+        <>
+            <BaseEdge id={id} path={path} style={style} markerEnd={markerEnd} />
+            <EdgeLabelRenderer>
+                <circle
+                    className="cursor-move fill-white stroke-gray-600"
+                    cx={control.x}
+                    cy={control.y}
+                    r={6}
+                    onMouseDown={onMouseDown}
+                />
+            </EdgeLabelRenderer>
+        </>
+    );
+};
+
+export default AdjustableEdge;

--- a/src/components/edges/AdjustableEdge.jsx
+++ b/src/components/edges/AdjustableEdge.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { BaseEdge, EdgeLabelRenderer, getSmoothStepPath, useReactFlow } from 'reactflow';
+import { BaseEdge, EdgeLabelRenderer, getSmoothStepPath, useReactFlow, useEdges } from 'reactflow';
 
 const AdjustableEdge = ({
     id,
@@ -13,6 +13,7 @@ const AdjustableEdge = ({
     markerStart,
     markerEnd,
     data,
+    selected,
 }) => {
     const { project, setEdges } = useReactFlow();
 
@@ -22,6 +23,54 @@ const AdjustableEdge = ({
     };
 
     const intersection = data?.intersection || 'none';
+
+    const edges = useEdges();
+
+    const getIntersections = () => {
+        const segs1 = [
+            [sourceX, sourceY, control.x, control.y],
+            [control.x, control.y, targetX, targetY],
+        ];
+        const res = [];
+        edges.forEach((edge) => {
+            if (edge.id === id) return;
+            const c2 = edge.data?.control || {
+                x: (edge.sourceX + edge.targetX) / 2,
+                y: (edge.sourceY + edge.targetY) / 2,
+            };
+            const segs2 = [
+                [edge.sourceX, edge.sourceY, c2.x, c2.y],
+                [c2.x, c2.y, edge.targetX, edge.targetY],
+            ];
+            segs1.forEach((s1) => {
+                segs2.forEach((s2) => {
+                    const p = segmentIntersect(s1, s2);
+                    if (p) res.push(p);
+                });
+            });
+        });
+        return res;
+    };
+
+    const segmentIntersect = (a, b) => {
+        const [x1, y1, x2, y2] = a;
+        const [x3, y3, x4, y4] = b;
+        const s1_x = x2 - x1;
+        const s1_y = y2 - y1;
+        const s2_x = x4 - x3;
+        const s2_y = y4 - y3;
+        const s = (-s1_y * (x1 - x3) + s1_x * (y1 - y3)) / (-s2_x * s1_y + s1_x * s2_y);
+        const t = ( s2_x * (y1 - y3) - s2_y * (x1 - x3)) / (-s2_x * s1_y + s1_x * s2_y);
+        if (s >= 0 && s <= 1 && t >= 0 && t <= 1) {
+            return {
+                x: x1 + (t * s1_x),
+                y: y1 + (t * s1_y),
+            };
+        }
+        return null;
+    };
+
+    const intersections = intersection === 'none' ? [] : getIntersections();
 
     const [smoothPath, labelX, labelY] = getSmoothStepPath({
         sourceX,
@@ -35,9 +84,9 @@ const AdjustableEdge = ({
 
     const quadraticPath = `M ${sourceX},${sourceY} Q ${control.x},${control.y} ${targetX},${targetY}`;
 
-    const path = intersection === 'curve' ? smoothPath : quadraticPath;
+    const path = intersection === 'arc' ? smoothPath : quadraticPath;
 
-    const labelPosition = intersection === 'curve'
+    const labelPosition = intersection === 'arc'
         ? { x: labelX, y: labelY }
         : {
             x: 0.25 * sourceX + 0.5 * control.x + 0.25 * targetX,
@@ -68,8 +117,8 @@ const AdjustableEdge = ({
         window.addEventListener('mouseup', onMouseUp);
     }, [updateControl]);
 
-    const edgeStyle = intersection === 'join'
-        ? { ...style, strokeLinejoin: 'round' }
+    const edgeStyle = intersection === 'sharp'
+        ? { ...style, strokeLinejoin: 'miter' }
         : style;
 
     const label = data?.label || '';
@@ -83,6 +132,26 @@ const AdjustableEdge = ({
                 markerStart={markerStart}
                 markerEnd={markerEnd}
             />
+            {intersections.map((p, idx) => (
+                intersection === 'arc' ? (
+                    <circle
+                        key={idx}
+                        cx={p.x}
+                        cy={p.y}
+                        r={6}
+                        fill="white"
+                        stroke={edgeStyle.stroke || '#555'}
+                        strokeWidth={edgeStyle.strokeWidth || 2}
+                    />
+                ) : (
+                    <path
+                        key={idx}
+                        d={`M ${p.x - 6} ${p.y - 6} L ${p.x + 6} ${p.y + 6} M ${p.x - 6} ${p.y + 6} L ${p.x + 6} ${p.y - 6}`}
+                        stroke={edgeStyle.stroke || '#555'}
+                        strokeWidth={edgeStyle.strokeWidth || 2}
+                    />
+                )
+            ))}
             <EdgeLabelRenderer>
                 {label && (
                     <div
@@ -109,6 +178,22 @@ const AdjustableEdge = ({
                     r={6}
                     onMouseDown={onMouseDown}
                 />
+                {selected && (
+                    <>
+                        <circle
+                            cx={sourceX}
+                            cy={sourceY}
+                            r={5}
+                            className="fill-white stroke-indigo-600"
+                        />
+                        <circle
+                            cx={targetX}
+                            cy={targetY}
+                            r={5}
+                            className="fill-white stroke-indigo-600"
+                        />
+                    </>
+                )}
             </EdgeLabelRenderer>
         </>
     );

--- a/src/components/edges/index.js
+++ b/src/components/edges/index.js
@@ -1,0 +1,3 @@
+import AdjustableEdge from './AdjustableEdge';
+
+export { AdjustableEdge };

--- a/src/components/editor/ArchitectureDiagramEditor.jsx
+++ b/src/components/editor/ArchitectureDiagramEditor.jsx
@@ -3,10 +3,11 @@ import { ReactFlowProvider } from 'reactflow';
 import ArchitectureDiagramEditorContent from './ArchitectureDiagramEditorContent';
 import 'reactflow/dist/style.css';
 
-const ArchitectureDiagramEditor = ({ diagram, style = {}, className }) => {
+const ArchitectureDiagramEditor = ({ diagram, style = {}, className, mode = 'light' }) => {
     const combinedStyle = { width: '100%', height: '100%', ...style };
+    const modeClass = mode === 'dark' ? 'dark' : '';
     return (
-        <div style={combinedStyle} className={className}>
+        <div style={combinedStyle} className={`${modeClass} ${className || ''}`}>
             <ReactFlowProvider>
                 <ArchitectureDiagramEditorContent initialDiagram={diagram} />
             </ReactFlowProvider>

--- a/src/components/editor/ArchitectureDiagramEditorContent.jsx
+++ b/src/components/editor/ArchitectureDiagramEditorContent.jsx
@@ -18,6 +18,7 @@ import HexagonNode from '../nodes/HexagonNode';
 import TriangleNode from '../nodes/TriangleNode';
 import ContainerNode from '../nodes/ContainerNode';
 import ComponentNode from '../nodes/ComponentNode';
+import { AdjustableEdge } from '../edges';
 
 // Import modal components
 import PromptModal from '../modals/PromptModal';
@@ -141,6 +142,10 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
         component: ComponentNode,
     }), []);
 
+    const edgeTypes = useMemo(() => ({
+        adjustable: AdjustableEdge
+    }), []);
+
     // Stable node label change handler
     const handleNodeLabelChange = useCallback((nodeId, label) => {
         setNodes((nds) =>
@@ -235,7 +240,7 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
                 source: connection.source,
                 target: connection.target,
                 label: connection.label,
-                type: connection.type || 'smoothstep',
+                type: connection.type || 'adjustable',
                 animated: connection.animated || false,
                 style: {
                     strokeWidth: 2,
@@ -244,7 +249,8 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
                 zIndex: connection.zIndex || 5,
                 data: {
                     label: connection.label,
-                    description: connection.description || ''
+                    description: connection.description || '',
+                    control: connection.control
                 }
             });
         });
@@ -349,7 +355,7 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
     }, [saveToHistory]);
 
     const defaultEdgeOptions = useMemo(() => ({
-        type: 'smoothstep',
+        type: 'adjustable',
         animated: false,
         style: { strokeWidth: 2 }
     }), []);
@@ -359,7 +365,7 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
         const newEdge = {
             ...params,
             id: `edge-${Date.now()}`,
-            type: 'smoothstep',
+            type: 'adjustable',
             animated: true,
             style: { strokeWidth: 2, zIndex: 5 },
             zIndex: 5,
@@ -785,6 +791,7 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
                 type: edge.type,
                 animated: edge.animated,
                 description: edge.data?.description,
+                control: edge.data?.control,
                 style: {
                     strokeWidth: edge.style?.strokeWidth || 2,
                     strokeDasharray: edge.style?.strokeDasharray,
@@ -1472,6 +1479,7 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
                     onEdgeClick={onEdgeClick}
                     onNodeDragStop={onNodeDragStop}
                     nodeTypes={nodeTypes}
+                    edgeTypes={edgeTypes}
                     fitView
                     snapToGrid={false}
                     defaultViewport={{ x: 0, y: 0, zoom: 1 }}

--- a/src/components/editor/ArchitectureDiagramEditorContent.jsx
+++ b/src/components/editor/ArchitectureDiagramEditorContent.jsx
@@ -1163,11 +1163,10 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
         const updated = [...nodes];
         const containers = updated.filter(n => n.type === 'container');
         let currentX = 50;
-        const containerSpacing = 50;
+        const containerSpacing = 60;
 
         containers.forEach(container => {
             const width = container.style?.width || 400;
-            const height = container.style?.height || 300;
             const containerY = 50;
 
             container.position = { x: currentX, y: containerY };
@@ -1189,12 +1188,20 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
                 };
             });
 
-            currentX += width + containerSpacing;
+            // expand container height to fit children
+            const rows = Math.ceil(children.length / cols);
+            const childHeight = 80; // default
+            const neededHeight = padding + rows * (childHeight + childSpacingY);
+            if (!container.style) container.style = {};
+            container.style.height = Math.max(container.style?.height || 300, neededHeight);
+
+            currentX += (container.style.width || width) + containerSpacing;
         });
 
         setNodes(updated);
+        updated.forEach(n => updateNodeInternals(n.id));
         saveToHistory();
-    }, [nodes, saveToHistory]);
+    }, [nodes, saveToHistory, updateNodeInternals]);
 
     // Enhanced selection operations
     const selectAllElements = useCallback(() => {

--- a/src/components/editor/ArchitectureDiagramEditorContent.jsx
+++ b/src/components/editor/ArchitectureDiagramEditorContent.jsx
@@ -3,6 +3,7 @@ import ReactFlow, {
     Controls,
     Background,
     addEdge,
+    reconnectEdge,
     MiniMap,
     Panel,
     applyNodeChanges,
@@ -356,6 +357,14 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
     const onNodeDragStop = useCallback(() => {
         saveToHistory();
     }, [saveToHistory]);
+
+    const onEdgeUpdateStart = useCallback(() => {}, []);
+    const onEdgeUpdateEnd = useCallback(() => {
+        saveToHistory();
+    }, [saveToHistory]);
+    const onEdgeUpdate = useCallback((oldEdge, newConnection) => {
+        setEdges((eds) => reconnectEdge(oldEdge, newConnection, eds));
+    }, []);
 
     const defaultEdgeOptions = useMemo(() => ({
         type: 'adjustable',
@@ -1486,6 +1495,9 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
                     onConnect={onConnect}
                     onSelectionChange={onSelectionChange}
                     onEdgeClick={onEdgeClick}
+                    onEdgeUpdate={onEdgeUpdate}
+                    onEdgeUpdateStart={onEdgeUpdateStart}
+                    onEdgeUpdateEnd={onEdgeUpdateEnd}
                     onNodeDragStop={onNodeDragStop}
                     nodeTypes={nodeTypes}
                     edgeTypes={edgeTypes}

--- a/src/components/editor/ArchitectureDiagramEditorContent.jsx
+++ b/src/components/editor/ArchitectureDiagramEditorContent.jsx
@@ -247,10 +247,13 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
                     zIndex: connection.zIndex || 5
                 },
                 zIndex: connection.zIndex || 5,
+                markerStart: connection.markerStart,
+                markerEnd: connection.markerEnd || { type: 'arrow' },
                 data: {
                     label: connection.label,
                     description: connection.description || '',
-                    control: connection.control
+                    control: connection.control,
+                    intersection: connection.intersection || 'none'
                 }
             });
         });
@@ -369,7 +372,8 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
             animated: true,
             style: { strokeWidth: 2, zIndex: 5 },
             zIndex: 5,
-            data: { label: '', description: '' }
+            markerEnd: { type: 'arrow' },
+            data: { label: '', description: '', intersection: 'none' }
         };
         setEdges((eds) => addEdge(newEdge, eds));
         saveToHistory();
@@ -438,6 +442,8 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
                                 zIndex: parseInt(value)
                             };
                         } else if (property === 'type' || property === 'animated') {
+                            return { ...edge, [property]: value };
+                        } else if (property === 'markerStart' || property === 'markerEnd') {
                             return { ...edge, [property]: value };
                         } else if (property.startsWith('style.')) {
                             const styleProp = property.replace('style.', '');
@@ -792,6 +798,9 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
                 animated: edge.animated,
                 description: edge.data?.description,
                 control: edge.data?.control,
+                markerStart: edge.markerStart,
+                markerEnd: edge.markerEnd,
+                intersection: edge.data?.intersection,
                 style: {
                     strokeWidth: edge.style?.strokeWidth || 2,
                     strokeDasharray: edge.style?.strokeDasharray,

--- a/src/components/editor/TailwindPropertyEditor.jsx
+++ b/src/components/editor/TailwindPropertyEditor.jsx
@@ -378,8 +378,8 @@ const TailwindPropertyEditor = ({ selectedNode, selectedEdge, onElementPropertyC
                                             className="w-full px-3 py-2 border-2 border-gray-200 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
                                         >
                                             <option value="none">None</option>
-                                            <option value="join">Join lines</option>
-                                            <option value="curve">Curve</option>
+                                            <option value="arc">Arc Jump</option>
+                                            <option value="sharp">Sharp Jump</option>
                                         </select>
                                     </div>
                                 )}

--- a/src/components/editor/TailwindPropertyEditor.jsx
+++ b/src/components/editor/TailwindPropertyEditor.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { ChevronRight, Check } from 'lucide-react';
+import { ChevronRight } from 'lucide-react';
 
 const TailwindPropertyEditor = ({ selectedNode, selectedEdge, onElementPropertyChange }) => {
     // Node properties
@@ -121,29 +121,6 @@ const TailwindPropertyEditor = ({ selectedNode, selectedEdge, onElementPropertyC
         }
     }, [onElementPropertyChange]);
 
-    if (!selectedNode && !selectedEdge) {
-        return (
-            <div className="w-72 max-h-[calc(100vh-200px)] overflow-y-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg">
-                <div className="py-3 px-4 bg-gradient-to-r from-indigo-500 to-purple-600 text-white font-semibold rounded-t-lg">
-                    Properties
-                </div>
-                <div className="p-4">
-                    <div className="text-center text-gray-500 dark:text-gray-400 py-6">
-                        <p>Select an element to edit its properties</p>
-                        <div className="mt-4 text-left text-sm bg-gray-50 dark:bg-gray-700 p-3 rounded-lg">
-                            <strong>Tips:</strong>
-                            <ul className="mt-2 pl-5 list-disc">
-                                <li className="mb-1">Click nodes or edges to select them</li>
-                                <li className="mb-1">Use Ctrl+C/V to copy/paste</li>
-                                <li className="mb-1">Use Delete key to remove elements</li>
-                                <li className="mb-1">Double-click to edit labels inline</li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        );
-    }
     // Node handlers
     const handleNodeDescriptionChange = useCallback((e) => {
         const value = e.target.value;
@@ -224,6 +201,29 @@ const TailwindPropertyEditor = ({ selectedNode, selectedEdge, onElementPropertyC
         onElementPropertyChange('edge', 'animated', checked);
     }, [onElementPropertyChange]);
 
+    if (!selectedNode && !selectedEdge) {
+        return (
+            <div className="w-72 max-h-[calc(100vh-200px)] overflow-y-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg">
+                <div className="py-3 px-4 bg-gradient-to-r from-indigo-500 to-purple-600 text-white font-semibold rounded-t-lg">
+                    Properties
+                </div>
+                <div className="p-4">
+                    <div className="text-center text-gray-500 dark:text-gray-400 py-6">
+                        <p>Select an element to edit its properties</p>
+                        <div className="mt-4 text-left text-sm bg-gray-50 dark:bg-gray-700 p-3 rounded-lg">
+                            <strong>Tips:</strong>
+                            <ul className="mt-2 pl-5 list-disc">
+                                <li className="mb-1">Click nodes or edges to select them</li>
+                                <li className="mb-1">Use Ctrl+C/V to copy/paste</li>
+                                <li className="mb-1">Use Delete key to remove elements</li>
+                                <li className="mb-1">Double-click to edit labels inline</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className={`w-72 bg-white dark:bg-gray-800 rounded-lg shadow-lg ${minimized ? 'overflow-hidden' : 'max-h-[calc(100vh-200px)] overflow-y-auto'}`}>

--- a/src/components/editor/TailwindPropertyEditor.jsx
+++ b/src/components/editor/TailwindPropertyEditor.jsx
@@ -20,6 +20,8 @@ const TailwindPropertyEditor = ({ selectedNode, selectedEdge, onElementPropertyC
     const [edgeStrokeColor, setEdgeStrokeColor] = useState('#999999');
     const [edgeStrokeDasharray, setEdgeStrokeDasharray] = useState('');
     const [edgeZIndex, setEdgeZIndex] = useState(5);
+    const [edgeMarkerOption, setEdgeMarkerOption] = useState('end');
+    const [edgeIntersection, setEdgeIntersection] = useState('none');
 
     // UI State
     const [expandedSections, setExpandedSections] = useState({
@@ -63,6 +65,13 @@ const TailwindPropertyEditor = ({ selectedNode, selectedEdge, onElementPropertyC
             setEdgeStrokeColor(selectedEdge.style?.stroke || '#999999');
             setEdgeStrokeDasharray(selectedEdge.style?.strokeDasharray || '');
             setEdgeZIndex(selectedEdge.zIndex || selectedEdge.style?.zIndex || 5);
+            const start = selectedEdge.markerStart?.type !== undefined ? selectedEdge.markerStart.type : 'none';
+            const end = selectedEdge.markerEnd?.type !== undefined ? selectedEdge.markerEnd.type : 'none';
+            if (start !== 'none' && end !== 'none') setEdgeMarkerOption('both');
+            else if (start !== 'none') setEdgeMarkerOption('start');
+            else if (end !== 'none') setEdgeMarkerOption('end');
+            else setEdgeMarkerOption('none');
+            setEdgeIntersection(selectedEdge.data?.intersection || 'none');
         }
     }, [selectedNode, selectedEdge]);
 
@@ -201,6 +210,35 @@ const TailwindPropertyEditor = ({ selectedNode, selectedEdge, onElementPropertyC
         onElementPropertyChange('edge', 'animated', checked);
     }, [onElementPropertyChange]);
 
+    const handleEdgeMarkerChange = useCallback((e) => {
+        const value = e.target.value;
+        setEdgeMarkerOption(value);
+        switch (value) {
+            case 'both':
+                onElementPropertyChange('edge', 'markerStart', { type: 'arrow' });
+                onElementPropertyChange('edge', 'markerEnd', { type: 'arrow' });
+                break;
+            case 'start':
+                onElementPropertyChange('edge', 'markerStart', { type: 'arrow' });
+                onElementPropertyChange('edge', 'markerEnd', undefined);
+                break;
+            case 'end':
+                onElementPropertyChange('edge', 'markerStart', undefined);
+                onElementPropertyChange('edge', 'markerEnd', { type: 'arrow' });
+                break;
+            default:
+                onElementPropertyChange('edge', 'markerStart', undefined);
+                onElementPropertyChange('edge', 'markerEnd', undefined);
+                break;
+        }
+    }, [onElementPropertyChange]);
+
+    const handleEdgeIntersectionChange = useCallback((e) => {
+        const value = e.target.value;
+        setEdgeIntersection(value);
+        onElementPropertyChange('edge', 'intersection', value);
+    }, [onElementPropertyChange]);
+
     if (!selectedNode && !selectedEdge) {
         return (
             <div className="w-72 max-h-[calc(100vh-200px)] overflow-y-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg">
@@ -313,6 +351,35 @@ const TailwindPropertyEditor = ({ selectedNode, selectedEdge, onElementPropertyC
                                             <option value="step">Step</option>
                                             <option value="smoothstep">Smooth Step</option>
                                             <option value="straight">Direct</option>
+                                        </select>
+                                    </div>
+                                )}
+                                {selectedEdge && (
+                                    <div className="mb-4">
+                                        <label className="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">Arrowheads:</label>
+                                        <select
+                                            value={edgeMarkerOption}
+                                            onChange={handleEdgeMarkerChange}
+                                            className="w-full px-3 py-2 border-2 border-gray-200 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                                        >
+                                            <option value="end">Pointing to Target</option>
+                                            <option value="start">Pointing from Target</option>
+                                            <option value="both">Both Ends</option>
+                                            <option value="none">None</option>
+                                        </select>
+                                    </div>
+                                )}
+                                {selectedEdge && (
+                                    <div className="mb-4">
+                                        <label className="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">Intersection Style:</label>
+                                        <select
+                                            value={edgeIntersection}
+                                            onChange={handleEdgeIntersectionChange}
+                                            className="w-full px-3 py-2 border-2 border-gray-200 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                                        >
+                                            <option value="none">None</option>
+                                            <option value="join">Join lines</option>
+                                            <option value="curve">Curve</option>
                                         </select>
                                     </div>
                                 )}

--- a/src/components/editor/TailwindPropertyEditor.jsx
+++ b/src/components/editor/TailwindPropertyEditor.jsx
@@ -144,20 +144,85 @@ const TailwindPropertyEditor = ({ selectedNode, selectedEdge, onElementPropertyC
             </div>
         );
     }
-    // Temporary stub handlers
-    const handleEdgeLabel = () => { };
-    const handleNodeDescriptionChange = () => { };
-    const handleEdgeDescriptionChange = () => { };
-    const handleNodeZIndexChange = () => { };
-    const handleEdgeZIndexChange = () => { };
-    const handleEdgeTypeChange = () => { };
-    const handleNodeColorChange = () => { };
-    const handleNodeBorderColorChange = () => { };
-    const handleNodeTextColorChange = () => { };
-    const handleEdgeStrokeColorChange = () => { };
-    const handleEdgeStrokeWidthChange = () => { };
-    const handleEdgeStrokeDasharrayChange = () => { };
-    const handleEdgeAnimatedChange = () => { };
+    // Node handlers
+    const handleNodeDescriptionChange = useCallback((e) => {
+        const value = e.target.value;
+        setNodeDescription(value);
+        onElementPropertyChange('node', 'description', value);
+    }, [onElementPropertyChange]);
+
+    const handleNodeZIndexChange = useCallback((e) => {
+        const value = parseInt(e.target.value, 10) || 0;
+        setNodeZIndex(value);
+        onElementPropertyChange('node', 'zIndex', value);
+    }, [onElementPropertyChange]);
+
+    const handleNodeColorChange = useCallback((e) => {
+        const value = e.target.value;
+        setNodeColor(value);
+        onElementPropertyChange('node', 'color', value);
+    }, [onElementPropertyChange]);
+
+    const handleNodeBorderColorChange = useCallback((e) => {
+        const value = e.target.value;
+        setNodeBorderColor(value);
+        onElementPropertyChange('node', 'borderColor', value);
+    }, [onElementPropertyChange]);
+
+    const handleNodeTextColorChange = useCallback((e) => {
+        const value = e.target.value;
+        setNodeTextColor(value);
+        onElementPropertyChange('node', 'textColor', value);
+    }, [onElementPropertyChange]);
+
+    // Edge handlers
+    const handleEdgeLabel = useCallback((e) => {
+        const value = e.target.value;
+        setEdgeLabel(value);
+        onElementPropertyChange('edge', 'label', value);
+    }, [onElementPropertyChange]);
+
+    const handleEdgeDescriptionChange = useCallback((e) => {
+        const value = e.target.value;
+        setEdgeDescription(value);
+        onElementPropertyChange('edge', 'description', value);
+    }, [onElementPropertyChange]);
+
+    const handleEdgeZIndexChange = useCallback((e) => {
+        const value = parseInt(e.target.value, 10) || 0;
+        setEdgeZIndex(value);
+        onElementPropertyChange('edge', 'zIndex', value);
+    }, [onElementPropertyChange]);
+
+    const handleEdgeTypeChange = useCallback((e) => {
+        const value = e.target.value;
+        setEdgeType(value);
+        onElementPropertyChange('edge', 'type', value);
+    }, [onElementPropertyChange]);
+
+    const handleEdgeStrokeColorChange = useCallback((e) => {
+        const value = e.target.value;
+        setEdgeStrokeColor(value);
+        onElementPropertyChange('edge', 'style.stroke', value);
+    }, [onElementPropertyChange]);
+
+    const handleEdgeStrokeWidthChange = useCallback((e) => {
+        const value = parseInt(e.target.value, 10) || 1;
+        setEdgeStrokeWidth(value);
+        onElementPropertyChange('edge', 'style.strokeWidth', value);
+    }, [onElementPropertyChange]);
+
+    const handleEdgeStrokeDasharrayChange = useCallback((e) => {
+        const value = e.target.value;
+        setEdgeStrokeDasharray(value);
+        onElementPropertyChange('edge', 'style.strokeDasharray', value);
+    }, [onElementPropertyChange]);
+
+    const handleEdgeAnimatedChange = useCallback((e) => {
+        const checked = e.target.checked;
+        setEdgeAnimated(checked);
+        onElementPropertyChange('edge', 'animated', checked);
+    }, [onElementPropertyChange]);
 
 
     return (
@@ -243,6 +308,7 @@ const TailwindPropertyEditor = ({ selectedNode, selectedEdge, onElementPropertyC
                                             onChange={handleEdgeTypeChange}
                                             className="w-full px-3 py-2 border-2 border-gray-200 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
                                         >
+                                            <option value="adjustable">Adjustable</option>
                                             <option value="default">Straight</option>
                                             <option value="step">Step</option>
                                             <option value="smoothstep">Smooth Step</option>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,9 +1,11 @@
 import ArchitectureDiagramEditor from './editor';
 import * as Nodes from './nodes';
 import * as Modals from './modals';
+import * as Edges from './edges';
 
 export {
     ArchitectureDiagramEditor,
     Nodes,
-    Modals
+    Modals,
+    Edges
 };

--- a/src/components/nodes/CircleNode.jsx
+++ b/src/components/nodes/CircleNode.jsx
@@ -85,10 +85,14 @@ const CircleNode = ({ data, id, selected, isConnectable }) => {
                 )}
 
                 {/* Connection handles */}
-                <Handle type="source" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="target" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="source" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="target" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="right-source" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="right-target" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="left-source" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="left-target" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="bottom-source" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="bottom-target" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="top-source" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="top-target" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
             </div>
         </>
     );

--- a/src/components/nodes/CircleNode.jsx
+++ b/src/components/nodes/CircleNode.jsx
@@ -1,9 +1,13 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { Handle, Position, NodeResizer } from 'reactflow';
 
 const CircleNode = ({ data, id, selected, isConnectable }) => {
     const [isEditing, setIsEditing] = useState(false);
     const [label, setLabel] = useState(data.label || 'Circle');
+
+    useEffect(() => {
+        setLabel(data.label || 'Circle');
+    }, [data.label]);
     const inputRef = useRef(null);
 
     const handleDoubleClick = useCallback((e) => {

--- a/src/components/nodes/ComponentNode.jsx
+++ b/src/components/nodes/ComponentNode.jsx
@@ -1,9 +1,13 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { Handle, Position, NodeResizer } from 'reactflow';
 
 const ComponentNode = ({ data, id, selected, isConnectable }) => {
     const [isEditing, setIsEditing] = useState(false);
     const [label, setLabel] = useState(data.label || 'Component');
+
+    useEffect(() => {
+        setLabel(data.label || 'Component');
+    }, [data.label]);
     const inputRef = useRef(null);
 
     const handleDoubleClick = useCallback((e) => {

--- a/src/components/nodes/ComponentNode.jsx
+++ b/src/components/nodes/ComponentNode.jsx
@@ -104,10 +104,14 @@ const ComponentNode = ({ data, id, selected, isConnectable }) => {
                 )}
 
                 {/* Connection handles */}
-                <Handle type="source" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="target" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="source" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="target" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="right-source" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="right-target" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="left-source" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="left-target" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="bottom-source" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="bottom-target" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="top-source" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="top-target" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
             </div>
         </>
     );

--- a/src/components/nodes/ContainerNode.jsx
+++ b/src/components/nodes/ContainerNode.jsx
@@ -1,9 +1,13 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { Handle, Position, NodeResizer } from 'reactflow';
 
 const ContainerNode = ({ data, id, selected, isConnectable }) => {
     const [isEditing, setIsEditing] = useState(false);
     const [label, setLabel] = useState(data.label || 'Container');
+
+    useEffect(() => {
+        setLabel(data.label || 'Container');
+    }, [data.label]);
     const inputRef = useRef(null);
 
     const handleDoubleClick = useCallback((e) => {

--- a/src/components/nodes/ContainerNode.jsx
+++ b/src/components/nodes/ContainerNode.jsx
@@ -117,10 +117,14 @@ const ContainerNode = ({ data, id, selected, isConnectable }) => {
                 </div>
 
                 {/* Connection handles */}
-                <Handle type="source" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="target" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="source" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="target" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="right-source" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="right-target" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="left-source" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="left-target" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="bottom-source" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="bottom-target" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="top-source" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="top-target" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
             </div>
         </>
     );

--- a/src/components/nodes/DiamondNode.jsx
+++ b/src/components/nodes/DiamondNode.jsx
@@ -1,9 +1,13 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { Handle, Position, NodeResizer } from 'reactflow';
 
 const DiamondNode = ({ data, id, selected, isConnectable }) => {
     const [isEditing, setIsEditing] = useState(false);
     const [label, setLabel] = useState(data.label || 'Diamond');
+
+    useEffect(() => {
+        setLabel(data.label || 'Diamond');
+    }, [data.label]);
     const inputRef = useRef(null);
 
     const handleDoubleClick = useCallback((e) => {

--- a/src/components/nodes/DiamondNode.jsx
+++ b/src/components/nodes/DiamondNode.jsx
@@ -99,10 +99,14 @@ const DiamondNode = ({ data, id, selected, isConnectable }) => {
                 </div>
 
                 {/* Connection handles */}
-                <Handle type="source" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="target" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="source" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="target" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="right-source" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="right-target" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="left-source" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="left-target" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="bottom-source" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="bottom-target" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="top-source" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="top-target" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
             </div>
         </>
     );

--- a/src/components/nodes/HexagonNode.jsx
+++ b/src/components/nodes/HexagonNode.jsx
@@ -1,9 +1,13 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { Handle, Position, NodeResizer } from 'reactflow';
 
 const HexagonNode = ({ data, id, selected, isConnectable }) => {
     const [isEditing, setIsEditing] = useState(false);
     const [label, setLabel] = useState(data.label || 'Hexagon');
+
+    useEffect(() => {
+        setLabel(data.label || 'Hexagon');
+    }, [data.label]);
     const inputRef = useRef(null);
 
     const handleDoubleClick = useCallback((e) => {

--- a/src/components/nodes/HexagonNode.jsx
+++ b/src/components/nodes/HexagonNode.jsx
@@ -85,10 +85,14 @@ const HexagonNode = ({ data, id, selected, isConnectable }) => {
                 )}
 
                 {/* Connection handles */}
-                <Handle type="source" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="target" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="source" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="target" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="right-source" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="right-target" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="left-source" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="left-target" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="bottom-source" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="bottom-target" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="top-source" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="top-target" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
             </div>
         </>
     );

--- a/src/components/nodes/TriangleNode.jsx
+++ b/src/components/nodes/TriangleNode.jsx
@@ -83,10 +83,14 @@ const TriangleNode = ({ data, id, selected }) => {
                 ) : (
                     <span style={{ fontSize: '14px' }}>{label}</span>
                 )}
-                <Handle type="source" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="target" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="source" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
-                <Handle type="target" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="right-source" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="right-target" position={Position.Right} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="left-source" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="left-target" position={Position.Left} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="bottom-source" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="bottom-target" position={Position.Bottom} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="source" id="top-source" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
+                <Handle type="target" id="top-target" position={Position.Top} style={{ background: '#555', width: 6, height: 6 }} />
             </div>
         </>
     );

--- a/src/components/nodes/TriangleNode.jsx
+++ b/src/components/nodes/TriangleNode.jsx
@@ -1,9 +1,13 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { Handle, Position, NodeResizer } from 'reactflow';
 
 const TriangleNode = ({ data, id, selected }) => {
     const [isEditing, setIsEditing] = useState(false);
     const [label, setLabel] = useState(data.label || 'Triangle');
+
+    useEffect(() => {
+        setLabel(data.label || 'Triangle');
+    }, [data.label]);
     const inputRef = useRef(null);
 
     const handleDoubleClick = useCallback((e) => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,5 +28,5 @@ module.exports = {
         },
     },
     plugins: [],
-    darkMode: 'media', // or 'class' for manual dark mode
+    darkMode: 'class',
 }


### PR DESCRIPTION
## Summary
- implement AdjustableEdge component to support draggable edge paths
- wire adjustable edges and edge types into editor
- expose `mode` prop for dark/light theme
- export new edges from package
- switch Tailwind to class-based dark mode

## Testing
- `npm test --silent`
- `npm run lib:build --silent`


------
https://chatgpt.com/codex/tasks/task_e_684974ddb4b48328af7e3ed7e7d06282