### PR TITLE
Fix theme and add toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ npm install path/to/graphing
 npm install graphing
 ```
 
-Import the editor and provide a diagram object. The optional `mode` prop controls the UI theme (`"dark"` or `"dark"`).
+Import the editor and provide a diagram object. The optional `mode` prop controls the initial UI theme (`"light"` or `"dark"`).
+You can also enable a built-in theme switcher in the View menu by passing `showThemeToggle`.
 
 ```jsx
 import { ArchitectureDiagramEditor } from 'graphing';
@@ -72,7 +73,7 @@ const example = {
 function Example() {
   return (
     <div style={{ width: 600, height: 400 }}>
-      <ArchitectureDiagramEditor diagram={example} mode="dark" />
+      <ArchitectureDiagramEditor diagram={example} mode="dark" showThemeToggle />
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import { ArchitectureDiagramEditor } from './components';
 function App() {
   return (
     <div className="w-full h-screen overflow-hidden">
-      <ArchitectureDiagramEditor />
+      <ArchitectureDiagramEditor showThemeToggle />
     </div>
   );
 }

--- a/src/components/editor/ArchitectureDiagramEditor.jsx
+++ b/src/components/editor/ArchitectureDiagramEditor.jsx
@@ -1,15 +1,28 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { ReactFlowProvider } from 'reactflow';
 import ArchitectureDiagramEditorContent from './ArchitectureDiagramEditorContent';
 import 'reactflow/dist/style.css';
 
-const ArchitectureDiagramEditor = ({ diagram, style = {}, className, mode = 'light' }) => {
+const ArchitectureDiagramEditor = ({ diagram, style = {}, className, mode = 'light', showThemeToggle = false }) => {
+    const [theme, setTheme] = useState(mode);
+
+    useEffect(() => {
+        setTheme(mode);
+    }, [mode]);
+
     const combinedStyle = { width: '100%', height: '100%', ...style };
-    const modeClass = mode === 'dark' ? 'dark' : '';
+    const modeClass = theme === 'dark' ? 'dark' : '';
+
+    const toggleTheme = () => setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+
     return (
         <div style={combinedStyle} className={`${modeClass} ${className || ''}`}>
             <ReactFlowProvider>
-                <ArchitectureDiagramEditorContent initialDiagram={diagram} />
+                <ArchitectureDiagramEditorContent
+                    initialDiagram={diagram}
+                    onToggleTheme={toggleTheme}
+                    showThemeToggle={showThemeToggle}
+                />
             </ReactFlowProvider>
         </div>
     );

--- a/src/components/editor/ArchitectureDiagramEditorContent.jsx
+++ b/src/components/editor/ArchitectureDiagramEditorContent.jsx
@@ -105,7 +105,7 @@ const ajv = new Ajv();
 const validateDiagram = ajv.compile(diagramSchema);
 
 
-const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
+const ArchitectureDiagramEditorContent = ({ initialDiagram, onToggleTheme, showThemeToggle }) => {
     // State for nodes and edges
     const [nodes, setNodes] = useState([]);
     const [edges, setEdges] = useState([]);
@@ -1448,6 +1448,8 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram }) => {
                     hasClipboard={clipboardData !== null}
                     canLink={selectedElements.nodes.length >= 2}
                     onTogglePropertiesPanel={togglePropertyPanel}
+                    onToggleTheme={onToggleTheme}
+                    showThemeToggle={showThemeToggle}
                 />
 
                 {/* Quick Action Buttons */}

--- a/src/components/editor/EnhancedMenuBar.jsx
+++ b/src/components/editor/EnhancedMenuBar.jsx
@@ -29,6 +29,8 @@ const EnhancedMenuBar = ({
   onValidateJSON,
   onAutoLayout,
   onTogglePropertiesPanel,
+  onToggleTheme,
+  showThemeToggle = false,
   canUndo = false,
   canRedo = false,
   hasSelection = false,
@@ -228,6 +230,11 @@ const EnhancedMenuBar = ({
         <MenuItem onClick={onTogglePropertiesPanel}>
           Toggle Properties Panel
         </MenuItem>
+        {showThemeToggle && (
+          <MenuItem onClick={onToggleTheme}>
+            Toggle Dark Mode
+          </MenuItem>
+        )}
       </MenuButton>
 
       <MenuButton name="Settings" icon={Settings}>


### PR DESCRIPTION
## Summary
- add theme state in `ArchitectureDiagramEditor`
- expose a View menu option for toggling theme
- pass optional `showThemeToggle` prop to hide the toggle for library usage
- document the new prop in README and example

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a86cbf6e4832897f2525ddc0f5e46