### PR TITLE
Fix GitHub Actions triggers and build script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
   pull_request:
     branches: [ main ]
   release:
@@ -59,7 +59,7 @@ jobs:
       run: npm ci
     
     - name: Build library
-      run: npm run lib:build
+      run: npm run build:lib
     
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
@@ -87,7 +87,7 @@ jobs:
       run: npm ci
     
     - name: Build library
-      run: npm run lib:build
+      run: npm run build:lib
     
     - name: Publish to NPM
       run: npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Auto Release
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
     paths-ignore:
       - 'README.md'
       - 'docs/**'
@@ -35,7 +35,7 @@ jobs:
       run: npm test -- --coverage --watchAll=false
     
     - name: Build library
-      run: npm run lib:build
+      run: npm run build:lib
     
     - name: Configure Git
       run: |
@@ -56,7 +56,7 @@ jobs:
     - name: Bump version and create tag
       run: |
         npm version ${{ steps.version_bump.outputs.bump }} -m "Release %s [skip-release]"
-        git push origin main --tags
+        git push origin master --tags
     
     - name: Get new version
       id: package_version


### PR DESCRIPTION
## Summary
- use `build:lib` script in workflows
- trigger on `master` branch to match repository
- push release tags to `master`

## Testing
- `npm ci --silent`
- `npm test -- --coverage --watchAll=false`
- `npm run build:lib --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a89ea5f348328b12d701cd8d974ad