### PR TITLE
Fix npm publish version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,18 @@ jobs:
     - name: Build library
       run: npm run build:lib
 
+    - name: Configure Git
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+
+    - name: Bump package version
+      run: |
+        npm version patch -m "Release %s [skip-release]"
+        git push origin HEAD --tags
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Publish to NPM
       run: npm publish --access public
       env:


### PR DESCRIPTION
## Summary
- bump package version before npm publish in CI

## Testing
- `npm ci`
- `npm test -- --coverage --watchAll=false` *(fails: No tests found related to files changed)*

------
https://chatgpt.com/codex/tasks/task_e_684a92167cc48328a1f6d7ffa5be5cc4