### PR TITLE
Improve editor fullscreen and property panel

### DIFF
--- a/src/components/editor/ArchitectureDiagramEditor.jsx
+++ b/src/components/editor/ArchitectureDiagramEditor.jsx
@@ -5,22 +5,31 @@ import 'reactflow/dist/style.css';
 
 const ArchitectureDiagramEditor = ({ diagram, style = {}, className, mode = 'light', showThemeToggle = false }) => {
     const [theme, setTheme] = useState(mode);
+    const [isFullscreen, setIsFullscreen] = useState(false);
 
     useEffect(() => {
         setTheme(mode);
     }, [mode]);
 
     const combinedStyle = { width: '100%', height: '100%', ...style };
+    const fullscreenStyle = isFullscreen
+        ? { position: 'fixed', inset: 0, width: '100vw', height: '100vh', zIndex: 1000 }
+        : {};
     const modeClass = theme === 'dark' ? 'dark' : '';
 
     const toggleTheme = () => setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+    const toggleFullscreen = () => setIsFullscreen((prev) => !prev);
+
+    const containerStyle = { ...combinedStyle, ...fullscreenStyle };
 
     return (
-        <div style={combinedStyle} className={`${modeClass} ${className || ''}`}>
+        <div style={containerStyle} className={`${modeClass} bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 relative ${className || ''}`}>
             <ReactFlowProvider>
                 <ArchitectureDiagramEditorContent
                     initialDiagram={diagram}
                     onToggleTheme={toggleTheme}
+                    onToggleFullscreen={toggleFullscreen}
+                    isFullscreen={isFullscreen}
                     showThemeToggle={showThemeToggle}
                 />
             </ReactFlowProvider>

--- a/src/components/editor/ArchitectureDiagramEditorContent.jsx
+++ b/src/components/editor/ArchitectureDiagramEditorContent.jsx
@@ -105,7 +105,7 @@ const ajv = new Ajv();
 const validateDiagram = ajv.compile(diagramSchema);
 
 
-const ArchitectureDiagramEditorContent = ({ initialDiagram, onToggleTheme, showThemeToggle }) => {
+const ArchitectureDiagramEditorContent = ({ initialDiagram, onToggleTheme, showThemeToggle, onToggleFullscreen, isFullscreen }) => {
     // State for nodes and edges
     const [nodes, setNodes] = useState([]);
     const [edges, setEdges] = useState([]);
@@ -1490,6 +1490,13 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram, onToggleTheme, showT
                         title="Paste (Ctrl+V)"
                     >
                         📄
+                    </button>
+                    <button
+                        className="p-2 rounded flex items-center justify-center w-9 h-9 text-white bg-white/10 border border-white/20 transition-all hover:bg-white/20 hover:-translate-y-0.5 hover:shadow-md"
+                        onClick={onToggleFullscreen}
+                        title={isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
+                    >
+                        {isFullscreen ? '🗗' : '🗖'}
                     </button>
                 </div>
             </div>

--- a/src/components/editor/TailwindPropertyEditor.jsx
+++ b/src/components/editor/TailwindPropertyEditor.jsx
@@ -306,7 +306,7 @@ const TailwindPropertyEditor = ({ selectedNode, selectedEdge, onElementPropertyC
 
     if (!selectedNode && !selectedEdge) {
         return (
-            <div className="w-72 max-h-[calc(100vh-200px)] overflow-y-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg">
+            <div className="w-72 max-w-[90vw] max-h-[calc(100vh-100px)] overflow-y-auto bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded-lg shadow-lg">
                 <div className="py-3 px-4 bg-gradient-to-r from-indigo-500 to-purple-600 text-white font-semibold rounded-t-lg">
                     Properties
                 </div>
@@ -329,7 +329,7 @@ const TailwindPropertyEditor = ({ selectedNode, selectedEdge, onElementPropertyC
     }
 
     return (
-        <div className={`w-72 bg-white dark:bg-gray-800 rounded-lg shadow-lg ${minimized ? 'overflow-hidden' : 'max-h-[calc(100vh-200px)] overflow-y-auto'}`}>
+        <div className={`w-72 max-w-[90vw] bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded-lg shadow-lg ${minimized ? 'overflow-hidden' : 'max-h-[calc(100vh-100px)] overflow-y-auto'}`}>
             <div className="flex items-center justify-between py-3 px-4 bg-gradient-to-r from-indigo-500 to-purple-600 text-white font-semibold rounded-t-lg">
                 <span>{selectedNode ? `${selectedNode.type || 'Node'} Properties` : 'Edge Properties'}</span>
                 <button className="text-xs" onClick={toggleMinimized}>{minimized ? 'Expand' : 'Minimize'}</button>


### PR DESCRIPTION
## Summary
- make editor container support fullscreen mode
- add fullscreen quick action button
- ensure property panel scrolls in small layouts
- set default text colors for light and dark

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaf99b1f0832894ea7ec464cda06b