### PR TITLE
Improve menu bar theming

### DIFF
--- a/src/components/editor/ArchitectureDiagramEditor.jsx
+++ b/src/components/editor/ArchitectureDiagramEditor.jsx
@@ -11,6 +11,12 @@ const ArchitectureDiagramEditor = ({ diagram, style = {}, className, mode = 'lig
         setTheme(mode);
     }, [mode]);
 
+    useEffect(() => {
+        const root = document.documentElement;
+        if (theme === 'dark') root.classList.add('dark');
+        else root.classList.remove('dark');
+    }, [theme]);
+
     const combinedStyle = { width: '100%', height: '100%', ...style };
     const fullscreenStyle = isFullscreen
         ? { position: 'fixed', inset: 0, width: '100vw', height: '100vh', zIndex: 1000 }

--- a/src/components/editor/ArchitectureDiagramEditorContent.jsx
+++ b/src/components/editor/ArchitectureDiagramEditorContent.jsx
@@ -1569,7 +1569,7 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram, onToggleTheme, showT
                 />
 
                 {/* Quick Action Buttons */}
-                <div className="flex items-center gap-2 p-2 bg-white/5 border-t border-white/10">
+                <div className="flex items-center gap-2 p-2 bg-gray-50 dark:bg-white/5 border-t border-gray-200 dark:border-white/10">
                     <button
                         className={`p-2 rounded flex items-center justify-center w-9 h-9 text-white bg-white/10 border border-white/20 transition-all ${history.past.length === 0 ? 'opacity-50 cursor-not-allowed' : 'hover:bg-white/20 hover:-translate-y-0.5 hover:shadow-md'
                             }`}

--- a/src/components/editor/EnhancedMenuBar.jsx
+++ b/src/components/editor/EnhancedMenuBar.jsx
@@ -76,9 +76,9 @@ const EnhancedMenuBar = ({
           }`}
         onClick={() => handleMenuClick(name)}
       >
-        <Icon size={16} />
+        <Icon size={16} className="stroke-current" />
         <span>{name}</span>
-        <ChevronDown size={12} />
+        <ChevronDown size={12} className="stroke-current" />
       </button>
 
       {activeMenu === name && (
@@ -103,7 +103,7 @@ const EnhancedMenuBar = ({
         onClick={disabled ? undefined : () => handleMenuItemClick(onClick)}
       >
         <span className="flex items-center gap-2">
-          {Icon && <Icon size={14} />}
+          {Icon && <Icon size={14} className="stroke-current" />}
           {children}
         </span>
         {shortcut && (
@@ -118,7 +118,7 @@ const EnhancedMenuBar = ({
   return (
     <div
       ref={menuRef}
-      className="flex items-center bg-gradient-to-r from-indigo-500 to-purple-600 p-0 relative z-10 border-b border-white/10"
+      className="flex items-center bg-gradient-to-r from-indigo-500 to-purple-600 dark:from-gray-800 dark:to-gray-700 text-gray-800 dark:text-gray-100 p-0 relative z-10 border-b border-white/10 dark:border-gray-800 transition-colors"
     >
       <MenuButton name="File" icon={File}>
         <MenuItem onClick={onNew} shortcut="Ctrl+N">


### PR DESCRIPTION
## Summary
- propagate dark class to document root so Tailwind dark mode works reliably
- theme the editor menu bar for dark mode
- ensure icons inherit text color
- adjust quick action bar styling for light/dark modes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b55fff1388328a6fa79ea2a7a1313