### PR TITLE
Implement controlled editor API and hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.12",
   "description": "A lightweight UML-style diagram editor built with React Flow and Tailwind CSS",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "README.md"
@@ -58,7 +59,8 @@
   "scripts": {
     "start": "cross-env PUBLIC_URL=/ HOST=0.0.0.0 PORT=3001 react-scripts start",
     "build": "react-scripts build",
-    "build:lib": "babel index.js --out-dir dist --copy-files && babel src/components --out-dir dist --copy-files",
+    "build:lib": "babel src --out-dir dist --copy-files && npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "build:css": "tailwindcss -i ./src/index.css -o ./dist/graphing.css --minify --postcss",
     "prepublishOnly": "npm run build:lib && npm run build:css",
     "test": "react-scripts test",

--- a/src/components/editor/ArchitectureDiagramEditor.jsx
+++ b/src/components/editor/ArchitectureDiagramEditor.jsx
@@ -1,45 +1,135 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { ReactFlowProvider } from 'reactflow';
 import ArchitectureDiagramEditorContent from './ArchitectureDiagramEditorContent';
 import 'reactflow/dist/style.css';
 import useThemeStore from '../store/themeStore';
 
-const ArchitectureDiagramEditor = ({ diagram, style = {}, className, mode = 'light', showThemeToggle = false, onToggleMini, showMiniToggle = false }) => {
-    const { theme, setTheme, toggleTheme } = useThemeStore();
-    const [isFullscreen, setIsFullscreen] = useState(false);
+const ArchitectureDiagramEditor = ({
+  value,
+  defaultValue,
+  onChange,
+  onNodeChange,
+  onConnectionChange,
+  onSelectionChange,
+  onError,
+  style = {},
+  className,
+  mode = 'light',
+  showThemeToggle = false,
+  onToggleMini,
+  showMiniToggle = false,
+  ...restProps
+}) => {
+  const { theme, setTheme, toggleTheme } = useThemeStore();
+  const isControlled = value !== undefined;
+  const [internalDiagram, setInternalDiagram] = useState(
+    defaultValue || { containers: [], nodes: [], connections: [] }
+  );
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
-    useEffect(() => {
-        setTheme(mode);
-    }, [mode]);
+  useEffect(() => {
+    setTheme(mode);
+  }, [mode]);
 
-    const combinedStyle = { width: '100%', height: '100%', ...style };
-    const fullscreenStyle = isFullscreen
-        ? { position: 'fixed', inset: 0, width: '100vw', height: '100vh', zIndex: 1000 }
-        : {};
-    const modeClass = theme === 'dark' ? 'dark' : '';
+  const currentDiagram = isControlled ? value : internalDiagram;
 
-    const handleToggleTheme = () => toggleTheme();
-    const toggleFullscreen = () => setIsFullscreen((prev) => !prev);
+  const handleDiagramUpdate = useCallback(
+    (newDiagram) => {
+      if (!isControlled) {
+        setInternalDiagram(newDiagram);
+      }
+      if (onChange) {
+        onChange(newDiagram);
+      }
+    },
+    [isControlled, onChange]
+  );
 
-    const containerStyle = { ...combinedStyle, ...fullscreenStyle };
+  const handleNodeUpdate = useCallback(
+    (nodeId, changes) => {
+      const updatedDiagram = {
+        ...currentDiagram,
+        nodes: currentDiagram.nodes.map((node) =>
+          node.id === nodeId ? { ...node, ...changes } : node
+        ),
+      };
+      handleDiagramUpdate(updatedDiagram);
+      if (onNodeChange) {
+        onNodeChange(nodeId, changes);
+      }
+    },
+    [currentDiagram, handleDiagramUpdate, onNodeChange]
+  );
 
-    return (
-        <div style={containerStyle} className={`graphing ${className || ''}`}>
-            <div className={`${modeClass} w-full h-full bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 relative transition-colors`}>
-                <ReactFlowProvider>
-                    <ArchitectureDiagramEditorContent
-                        initialDiagram={diagram}
-                        onToggleTheme={handleToggleTheme}
-                        onToggleFullscreen={toggleFullscreen}
-                        isFullscreen={isFullscreen}
-                        showThemeToggle={showThemeToggle}
-                        onToggleMini={onToggleMini}
-                        showMiniToggle={showMiniToggle}
-                    />
-                </ReactFlowProvider>
-            </div>
-        </div>
-    );
+  const handleConnectionUpdate = useCallback(
+    (connectionId, changes) => {
+      const updatedDiagram = {
+        ...currentDiagram,
+        connections: currentDiagram.connections.map((conn) =>
+          conn.id === connectionId ? { ...conn, ...changes } : conn
+        ),
+      };
+      handleDiagramUpdate(updatedDiagram);
+      if (onConnectionChange) {
+        onConnectionChange(connectionId, changes);
+      }
+    },
+    [currentDiagram, handleDiagramUpdate, onConnectionChange]
+  );
+
+  const handleSelectionUpdate = useCallback(
+    (selection) => {
+      if (onSelectionChange) {
+        onSelectionChange(selection);
+      }
+    },
+    [onSelectionChange]
+  );
+
+  const handleError = useCallback(
+    (error) => {
+      if (onError) {
+        onError(error);
+      }
+    },
+    [onError]
+  );
+
+  const combinedStyle = { width: '100%', height: '100%', ...style };
+  const fullscreenStyle = isFullscreen
+    ? { position: 'fixed', inset: 0, width: '100vw', height: '100vh', zIndex: 1000 }
+    : {};
+  const modeClass = theme === 'dark' ? 'dark' : '';
+
+  const handleToggleTheme = () => toggleTheme();
+  const toggleFullscreen = () => setIsFullscreen((prev) => !prev);
+
+  const containerStyle = { ...combinedStyle, ...fullscreenStyle };
+
+  return (
+    <div style={containerStyle} className={`graphing ${className || ''}`} {...restProps}>
+      <div
+        className={`${modeClass} w-full h-full bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 relative transition-colors`}
+      >
+        <ReactFlowProvider>
+          <ArchitectureDiagramEditorContent
+            initialDiagram={currentDiagram}
+            onToggleTheme={handleToggleTheme}
+            onToggleFullscreen={toggleFullscreen}
+            isFullscreen={isFullscreen}
+            showThemeToggle={showThemeToggle}
+            onToggleMini={onToggleMini}
+            showMiniToggle={showMiniToggle}
+            onNodeChange={handleNodeUpdate}
+            onConnectionChange={handleConnectionUpdate}
+            onSelectionChange={handleSelectionUpdate}
+            onDiagramChange={handleDiagramUpdate}
+            onError={handleError}
+          />
+        </ReactFlowProvider>
+      </div>
+    </div>
+  );
 };
 
 export default ArchitectureDiagramEditor;

--- a/src/components/editor/ArchitectureDiagramEditorContent.jsx
+++ b/src/components/editor/ArchitectureDiagramEditorContent.jsx
@@ -107,7 +107,20 @@ const ajv = new Ajv();
 const validateDiagram = ajv.compile(diagramSchema);
 
 
-const ArchitectureDiagramEditorContent = ({ initialDiagram, onToggleTheme, showThemeToggle, onToggleFullscreen, isFullscreen, onToggleMini, showMiniToggle }) => {
+const ArchitectureDiagramEditorContent = ({
+    initialDiagram,
+    onToggleTheme,
+    showThemeToggle,
+    onToggleFullscreen,
+    isFullscreen,
+    onToggleMini,
+    showMiniToggle,
+    onNodeChange,
+    onConnectionChange,
+    onSelectionChange: onSelectionChangeProp,
+    onDiagramChange,
+    onError
+}) => {
     // State for nodes and edges
     const [nodes, setNodes] = useState([]);
     const [edges, setEdges] = useState([]);
@@ -119,6 +132,99 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram, onToggleTheme, showT
     const [propertyPanelMinimized, setPropertyPanelMinimized] = useState(false);
     const [statsPanelOpen, setStatsPanelOpen] = useState(true);
     const [panMode, setPanMode] = useState(false);
+
+    const getDiagramData = useCallback(() => ({
+        containers: nodes
+            .filter((node) => node.type === 'container')
+            .map((container) => ({
+                id: container.id,
+                label: container.data.label,
+                position: container.position,
+                size: {
+                    width: container.style?.width || 400,
+                    height: container.style?.height || 300,
+                },
+                color: container.data.color,
+                bgColor: container.data.bgColor,
+                borderColor: container.data.borderColor,
+                icon: container.data.icon,
+                description: container.data.description,
+                zIndex: container.zIndex || 1
+            })),
+        nodes: nodes
+            .filter((node) => node.type !== 'container')
+            .map((node) => ({
+                id: node.id,
+                label: node.data.label,
+                type: node.type,
+                position: node.position,
+                parentContainer: node.parentNode,
+                size: {
+                    width: node.style?.width || 150,
+                    height: node.style?.height || 80,
+                },
+                color: node.data.color,
+                borderColor: node.data.borderColor,
+                icon: node.data.icon,
+                description: node.data.description,
+                zIndex: node.zIndex || 10
+            })),
+        connections: edges.map((edge) => ({
+            id: edge.id,
+            source: edge.source,
+            target: edge.target,
+            label: edge.data?.label,
+            type: edge.type,
+            animated: edge.animated,
+            description: edge.data?.description,
+            control: edge.data?.control,
+            markerStart: edge.markerStart,
+            markerEnd: edge.markerEnd,
+            intersection: edge.data?.intersection,
+            style: {
+                strokeWidth: edge.style?.strokeWidth || 2,
+                strokeDasharray: edge.style?.strokeDasharray,
+            },
+            zIndex: edge.zIndex || 5
+        }))
+    }), [nodes, edges]);
+
+    const prevDiagramRef = useRef(getDiagramData());
+
+    useEffect(() => {
+        const newDiagram = getDiagramData();
+        const prevDiagram = prevDiagramRef.current;
+
+        if (JSON.stringify(newDiagram) === JSON.stringify(prevDiagram)) {
+            return;
+        }
+
+        if (onDiagramChange) {
+            onDiagramChange(newDiagram);
+        }
+
+        if (onNodeChange) {
+            const prevNodesMap = Object.fromEntries(prevDiagram.nodes.map(n => [n.id, n]));
+            newDiagram.nodes.forEach(n => {
+                const prev = prevNodesMap[n.id];
+                if (!prev || JSON.stringify(prev) !== JSON.stringify(n)) {
+                    onNodeChange(n.id, n);
+                }
+            });
+        }
+
+        if (onConnectionChange) {
+            const prevEdgesMap = Object.fromEntries(prevDiagram.connections.map(e => [e.id, e]));
+            newDiagram.connections.forEach(e => {
+                const prev = prevEdgesMap[e.id];
+                if (!prev || JSON.stringify(prev) !== JSON.stringify(e)) {
+                    onConnectionChange(e.id, e);
+                }
+            });
+        }
+
+        prevDiagramRef.current = newDiagram;
+    }, [nodes, edges, onDiagramChange, onNodeChange, onConnectionChange, getDiagramData]);
 
     const getDiagramBounds = useCallback(() => {
         if (nodes.length === 0) return { x: 0, y: 0, width: 0, height: 0 };
@@ -319,6 +425,18 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram, onToggleTheme, showT
                 future: [],
             });
             setIsInitialized(true);
+            return;
+        }
+
+        if (initialDiagram) {
+            const { nodes: newNodes, edges: newEdges } = jsonToReactFlow(initialDiagram);
+            setNodes(newNodes);
+            setEdges(newEdges);
+            setHistory({
+                past: [],
+                present: { nodes: newNodes, edges: newEdges },
+                future: [],
+            });
         }
     }, [isInitialized, jsonToReactFlow, initialDiagram]);
 
@@ -450,11 +568,18 @@ const ArchitectureDiagramEditorContent = ({ initialDiagram, onToggleTheme, showT
 
     // Handle selection changes - now includes edges
     const onSelectionChange = useCallback(({ nodes: selectedNodes, edges: selectedEdges }) => {
-        setSelectedElements({
+        const selection = {
             nodes: selectedNodes || [],
             edges: selectedEdges || [],
-        });
-    }, []);
+        };
+        setSelectedElements(selection);
+        if (onSelectionChangeProp) {
+            onSelectionChangeProp({
+                nodes: selection.nodes.map((n) => n.id || n),
+                connections: selection.edges.map((e) => e.id || e)
+            });
+        }
+    }, [onSelectionChangeProp]);
 
     // Handle edge click - now uses property panel instead of modal
     const onEdgeClick = useCallback((event, edge) => {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,11 +1,7 @@
-import ArchitectureDiagramEditor from './editor';
-import * as Nodes from './nodes';
-import * as Modals from './modals';
-import * as Edges from './edges';
-
-export {
-    ArchitectureDiagramEditor,
-    Nodes,
-    Modals,
-    Edges
-};
+export { default as ArchitectureDiagramEditor } from './editor';
+export * as Nodes from './nodes';
+export * as Modals from './modals';
+export * as Edges from './edges';
+export { useDiagram } from '../hooks/useDiagram';
+export { useSelection } from '../hooks/useSelection';
+export * from '../types';

--- a/src/hooks/useDiagram.js
+++ b/src/hooks/useDiagram.js
@@ -1,0 +1,110 @@
+import { useState, useCallback } from 'react';
+
+export const useDiagram = (initialDiagram = { containers: [], nodes: [], connections: [] }) => {
+  const [diagram, setDiagram] = useState(initialDiagram);
+  const [history, setHistory] = useState([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const [selection, setSelection] = useState({ nodes: [], connections: [] });
+
+  const addToHistory = useCallback((newDiagram) => {
+    setHistory(prev => {
+      const newHistory = prev.slice(0, historyIndex + 1);
+      newHistory.push(newDiagram);
+      return newHistory;
+    });
+    setHistoryIndex(prev => prev + 1);
+  }, [historyIndex]);
+
+  const updateDiagram = useCallback((newDiagram) => {
+    setDiagram(newDiagram);
+    addToHistory(newDiagram);
+  }, [addToHistory]);
+
+  const addNode = useCallback((node) => {
+    const newNode = {
+      id: `node-${Date.now()}`,
+      position: { x: 100, y: 100 },
+      type: 'component',
+      size: { width: 150, height: 80 },
+      ...node
+    };
+
+    const newDiagram = {
+      ...diagram,
+      nodes: [...diagram.nodes, newNode]
+    };
+
+    updateDiagram(newDiagram);
+  }, [diagram, updateDiagram]);
+
+  const updateNode = useCallback((nodeId, changes) => {
+    const newDiagram = {
+      ...diagram,
+      nodes: diagram.nodes.map(node =>
+        node.id === nodeId ? { ...node, ...changes } : node
+      )
+    };
+
+    updateDiagram(newDiagram);
+  }, [diagram, updateDiagram]);
+
+  const deleteNode = useCallback((nodeId) => {
+    const newDiagram = {
+      ...diagram,
+      nodes: diagram.nodes.filter(node => node.id !== nodeId),
+      connections: diagram.connections.filter(conn =>
+        conn.source !== nodeId && conn.target !== nodeId
+      )
+    };
+
+    updateDiagram(newDiagram);
+  }, [diagram, updateDiagram]);
+
+  const addConnection = useCallback((connection) => {
+    const newConnection = {
+      id: `connection-${Date.now()}`,
+      type: 'floating',
+      animated: false,
+      ...connection
+    };
+
+    const newDiagram = {
+      ...diagram,
+      connections: [...diagram.connections, newConnection]
+    };
+
+    updateDiagram(newDiagram);
+  }, [diagram, updateDiagram]);
+
+  const undo = useCallback(() => {
+    if (historyIndex > 0) {
+      const newIndex = historyIndex - 1;
+      setHistoryIndex(newIndex);
+      setDiagram(history[newIndex]);
+    }
+  }, [history, historyIndex]);
+
+  const redo = useCallback(() => {
+    if (historyIndex < history.length - 1) {
+      const newIndex = historyIndex + 1;
+      setHistoryIndex(newIndex);
+      setDiagram(history[newIndex]);
+    }
+  }, [history, historyIndex]);
+
+  return {
+    diagram,
+    setDiagram: updateDiagram,
+    addNode,
+    updateNode,
+    deleteNode,
+    addConnection,
+    undo,
+    redo,
+    canUndo: historyIndex > 0,
+    canRedo: historyIndex < history.length - 1,
+    selection,
+    setSelection,
+    clearSelection: () => setSelection({ nodes: [], connections: [] })
+  };
+};

--- a/src/hooks/useSelection.js
+++ b/src/hooks/useSelection.js
@@ -1,0 +1,11 @@
+import { useState, useCallback } from 'react';
+
+export const useSelection = (initialSelection = { nodes: [], connections: [] }) => {
+  const [selection, setSelection] = useState(initialSelection);
+
+  const clearSelection = useCallback(() => {
+    setSelection({ nodes: [], connections: [] });
+  }, []);
+
+  return { selection, setSelection, clearSelection };
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,66 @@
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export interface Node {
+  id: string;
+  label: string;
+  position: Position;
+  size?: Size;
+  type?: string;
+  icon?: string;
+  color?: string;
+  borderColor?: string;
+  description?: string;
+  parentContainer?: string;
+}
+
+export interface Container {
+  id: string;
+  label: string;
+  position: Position;
+  size: Size;
+  icon?: string;
+  color?: string;
+  borderColor?: string;
+  description?: string;
+}
+
+export interface Connection {
+  id: string;
+  source: string;
+  target: string;
+  label?: string;
+  type?: string;
+  animated?: boolean;
+  description?: string;
+  style?: Record<string, any>;
+}
+
+export interface DiagramData {
+  containers: Container[];
+  nodes: Node[];
+  connections: Connection[];
+  metadata?: Record<string, any>;
+}
+
+export interface ArchitectureDiagramEditorProps {
+  value?: DiagramData;
+  defaultValue?: DiagramData;
+  onChange?: (diagram: DiagramData) => void;
+  onNodeChange?: (nodeId: string, changes: Partial<Node>) => void;
+  onConnectionChange?: (connectionId: string, changes: Partial<Connection>) => void;
+  onSelectionChange?: (selection: { nodes: string[]; connections: string[] }) => void;
+  onError?: (error: Error) => void;
+  style?: React.CSSProperties;
+  className?: string;
+  mode?: 'light' | 'dark';
+  readOnly?: boolean;
+  disabled?: boolean;
+}


### PR DESCRIPTION
## Summary
- update `ArchitectureDiagramEditor` to support controlled/uncontrolled usage
- expose diagram editing callbacks from `ArchitectureDiagramEditorContent`
- add new React hooks `useDiagram` and `useSelection`
- expose all components and hooks through `src/components/index.js`
- provide TypeScript type definitions
- update build scripts and types entry in `package.json`
- prevent callback loops in `ArchitectureDiagramEditorContent`

## Testing
- `npm install`
- `CI=true npm test` *(fails: no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68532a231cbc8328845e0e7e3b07d649