### PR TITLE
Implement controlled editor API and hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
 // Automatically include the bundled styles when the library is imported
-import './dist/graphing.css';
+import './graphing.css';
 
-export * from './src/components/index.js';
+// Re-export the compiled component library
+export * from './components/index.js';
+export * from './hooks/useDiagram.js';
+export * from './hooks/useSelection.js';
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.12",
   "description": "A lightweight UML-style diagram editor built with React Flow and Tailwind CSS",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "README.md"
@@ -58,9 +59,12 @@
   "scripts": {
     "start": "cross-env PUBLIC_URL=/ HOST=0.0.0.0 PORT=3001 react-scripts start",
     "build": "react-scripts build",
-    "build:lib": "babel index.js --out-dir dist --copy-files && babel src/components --out-dir dist --copy-files",
+    "build:lib": "npm run build:js && npm run build:types",
+    "build:js": "babel src/components --out-dir dist/components --copy-files && babel src/hooks --out-dir dist/hooks --copy-files && babel index.js --out-file dist/index.js",
+    "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "build:css": "tailwindcss -i ./src/index.css -o ./dist/graphing.css --minify --postcss",
     "prepublishOnly": "npm run build:lib && npm run build:css",
+    "prepare": "npm run build:lib && npm run build:css",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/components/editor/ArchitectureDiagramEditor.jsx
+++ b/src/components/editor/ArchitectureDiagramEditor.jsx
@@ -1,45 +1,138 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { ReactFlowProvider } from 'reactflow';
 import ArchitectureDiagramEditorContent from './ArchitectureDiagramEditorContent';
 import 'reactflow/dist/style.css';
 import useThemeStore from '../store/themeStore';
 
-const ArchitectureDiagramEditor = ({ diagram, style = {}, className, mode = 'light', showThemeToggle = false, onToggleMini, showMiniToggle = false }) => {
-    const { theme, setTheme, toggleTheme } = useThemeStore();
-    const [isFullscreen, setIsFullscreen] = useState(false);
+const ArchitectureDiagramEditor = ({
+  value,
+  defaultValue,
+  diagram,
+  onChange,
+  onNodeChange,
+  onConnectionChange,
+  onSelectionChange,
+  onError,
+  style = {},
+  className,
+  mode = 'light',
+  showThemeToggle = false,
+  onToggleMini,
+  showMiniToggle = false,
+  ...restProps
+}) => {
+  const { theme, setTheme, toggleTheme } = useThemeStore();
+  const isControlled = value !== undefined;
+  const initialDiagram =
+    defaultValue !== undefined ? defaultValue : diagram;
+  const [internalDiagram, setInternalDiagram] = useState(
+    initialDiagram || { containers: [], nodes: [], connections: [] }
+  );
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
-    useEffect(() => {
-        setTheme(mode);
-    }, [mode]);
+  useEffect(() => {
+    setTheme(mode);
+  }, [mode]);
 
-    const combinedStyle = { width: '100%', height: '100%', ...style };
-    const fullscreenStyle = isFullscreen
-        ? { position: 'fixed', inset: 0, width: '100vw', height: '100vh', zIndex: 1000 }
-        : {};
-    const modeClass = theme === 'dark' ? 'dark' : '';
+  const currentDiagram = isControlled ? value : internalDiagram;
 
-    const handleToggleTheme = () => toggleTheme();
-    const toggleFullscreen = () => setIsFullscreen((prev) => !prev);
+  const handleDiagramUpdate = useCallback(
+    (newDiagram) => {
+      if (!isControlled) {
+        setInternalDiagram(newDiagram);
+      }
+      if (onChange) {
+        onChange(newDiagram);
+      }
+    },
+    [isControlled, onChange]
+  );
 
-    const containerStyle = { ...combinedStyle, ...fullscreenStyle };
+  const handleNodeUpdate = useCallback(
+    (nodeId, changes) => {
+      const updatedDiagram = {
+        ...currentDiagram,
+        nodes: currentDiagram.nodes.map((node) =>
+          node.id === nodeId ? { ...node, ...changes } : node
+        ),
+      };
+      handleDiagramUpdate(updatedDiagram);
+      if (onNodeChange) {
+        onNodeChange(nodeId, changes);
+      }
+    },
+    [currentDiagram, handleDiagramUpdate, onNodeChange]
+  );
 
-    return (
-        <div style={containerStyle} className={`graphing ${className || ''}`}>
-            <div className={`${modeClass} w-full h-full bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 relative transition-colors`}>
-                <ReactFlowProvider>
-                    <ArchitectureDiagramEditorContent
-                        initialDiagram={diagram}
-                        onToggleTheme={handleToggleTheme}
-                        onToggleFullscreen={toggleFullscreen}
-                        isFullscreen={isFullscreen}
-                        showThemeToggle={showThemeToggle}
-                        onToggleMini={onToggleMini}
-                        showMiniToggle={showMiniToggle}
-                    />
-                </ReactFlowProvider>
-            </div>
-        </div>
-    );
+  const handleConnectionUpdate = useCallback(
+    (connectionId, changes) => {
+      const updatedDiagram = {
+        ...currentDiagram,
+        connections: currentDiagram.connections.map((conn) =>
+          conn.id === connectionId ? { ...conn, ...changes } : conn
+        ),
+      };
+      handleDiagramUpdate(updatedDiagram);
+      if (onConnectionChange) {
+        onConnectionChange(connectionId, changes);
+      }
+    },
+    [currentDiagram, handleDiagramUpdate, onConnectionChange]
+  );
+
+  const handleSelectionUpdate = useCallback(
+    (selection) => {
+      if (onSelectionChange) {
+        onSelectionChange(selection);
+      }
+    },
+    [onSelectionChange]
+  );
+
+  const handleError = useCallback(
+    (error) => {
+      if (onError) {
+        onError(error);
+      }
+    },
+    [onError]
+  );
+
+  const combinedStyle = { width: '100%', height: '100%', ...style };
+  const fullscreenStyle = isFullscreen
+    ? { position: 'fixed', inset: 0, width: '100vw', height: '100vh', zIndex: 1000 }
+    : {};
+  const modeClass = theme === 'dark' ? 'dark' : '';
+
+  const handleToggleTheme = () => toggleTheme();
+  const toggleFullscreen = () => setIsFullscreen((prev) => !prev);
+
+  const containerStyle = { ...combinedStyle, ...fullscreenStyle };
+
+  return (
+    <div style={containerStyle} className={`graphing ${className || ''}`} {...restProps}>
+      <div
+        className={`${modeClass} w-full h-full bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 relative transition-colors`}
+      >
+        <ReactFlowProvider>
+          <ArchitectureDiagramEditorContent
+            diagram={currentDiagram}
+            onToggleTheme={handleToggleTheme}
+            onToggleFullscreen={toggleFullscreen}
+            isFullscreen={isFullscreen}
+            showThemeToggle={showThemeToggle}
+            onToggleMini={onToggleMini}
+            showMiniToggle={showMiniToggle}
+            onNodeChange={handleNodeUpdate}
+            onConnectionChange={handleConnectionUpdate}
+            onSelectionChange={handleSelectionUpdate}
+            onDiagramChange={handleDiagramUpdate}
+            onError={handleError}
+          />
+        </ReactFlowProvider>
+      </div>
+    </div>
+  );
 };
 
 export default ArchitectureDiagramEditor;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,11 +1,6 @@
-import ArchitectureDiagramEditor from './editor';
-import * as Nodes from './nodes';
-import * as Modals from './modals';
-import * as Edges from './edges';
-
-export {
-    ArchitectureDiagramEditor,
-    Nodes,
-    Modals,
-    Edges
-};
+export { default as ArchitectureDiagramEditor } from './editor';
+export * as Nodes from './nodes';
+export * as Modals from './modals';
+export * as Edges from './edges';
+export { useDiagram } from '../hooks/useDiagram';
+export { useSelection } from '../hooks/useSelection';

--- a/src/hooks/useDiagram.js
+++ b/src/hooks/useDiagram.js
@@ -1,0 +1,110 @@
+import { useState, useCallback } from 'react';
+
+export const useDiagram = (initialDiagram = { containers: [], nodes: [], connections: [] }) => {
+  const [diagram, setDiagram] = useState(initialDiagram);
+  const [history, setHistory] = useState([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const [selection, setSelection] = useState({ nodes: [], connections: [] });
+
+  const addToHistory = useCallback((newDiagram) => {
+    setHistory(prev => {
+      const newHistory = prev.slice(0, historyIndex + 1);
+      newHistory.push(newDiagram);
+      return newHistory;
+    });
+    setHistoryIndex(prev => prev + 1);
+  }, [historyIndex]);
+
+  const updateDiagram = useCallback((newDiagram) => {
+    setDiagram(newDiagram);
+    addToHistory(newDiagram);
+  }, [addToHistory]);
+
+  const addNode = useCallback((node) => {
+    const newNode = {
+      id: `node-${Date.now()}`,
+      position: { x: 100, y: 100 },
+      type: 'component',
+      size: { width: 150, height: 80 },
+      ...node
+    };
+
+    const newDiagram = {
+      ...diagram,
+      nodes: [...diagram.nodes, newNode]
+    };
+
+    updateDiagram(newDiagram);
+  }, [diagram, updateDiagram]);
+
+  const updateNode = useCallback((nodeId, changes) => {
+    const newDiagram = {
+      ...diagram,
+      nodes: diagram.nodes.map(node =>
+        node.id === nodeId ? { ...node, ...changes } : node
+      )
+    };
+
+    updateDiagram(newDiagram);
+  }, [diagram, updateDiagram]);
+
+  const deleteNode = useCallback((nodeId) => {
+    const newDiagram = {
+      ...diagram,
+      nodes: diagram.nodes.filter(node => node.id !== nodeId),
+      connections: diagram.connections.filter(conn =>
+        conn.source !== nodeId && conn.target !== nodeId
+      )
+    };
+
+    updateDiagram(newDiagram);
+  }, [diagram, updateDiagram]);
+
+  const addConnection = useCallback((connection) => {
+    const newConnection = {
+      id: `connection-${Date.now()}`,
+      type: 'floating',
+      animated: false,
+      ...connection
+    };
+
+    const newDiagram = {
+      ...diagram,
+      connections: [...diagram.connections, newConnection]
+    };
+
+    updateDiagram(newDiagram);
+  }, [diagram, updateDiagram]);
+
+  const undo = useCallback(() => {
+    if (historyIndex > 0) {
+      const newIndex = historyIndex - 1;
+      setHistoryIndex(newIndex);
+      setDiagram(history[newIndex]);
+    }
+  }, [history, historyIndex]);
+
+  const redo = useCallback(() => {
+    if (historyIndex < history.length - 1) {
+      const newIndex = historyIndex + 1;
+      setHistoryIndex(newIndex);
+      setDiagram(history[newIndex]);
+    }
+  }, [history, historyIndex]);
+
+  return {
+    diagram,
+    setDiagram: updateDiagram,
+    addNode,
+    updateNode,
+    deleteNode,
+    addConnection,
+    undo,
+    redo,
+    canUndo: historyIndex > 0,
+    canRedo: historyIndex < history.length - 1,
+    selection,
+    setSelection,
+    clearSelection: () => setSelection({ nodes: [], connections: [] })
+  };
+};

--- a/src/hooks/useSelection.js
+++ b/src/hooks/useSelection.js
@@ -1,0 +1,11 @@
+import { useState, useCallback } from 'react';
+
+export const useSelection = (initialSelection = { nodes: [], connections: [] }) => {
+  const [selection, setSelection] = useState(initialSelection);
+
+  const clearSelection = useCallback(() => {
+    setSelection({ nodes: [], connections: [] });
+  }, []);
+
+  return { selection, setSelection, clearSelection };
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,71 @@
+import type { CSSProperties } from "react";
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export interface Node {
+  id: string;
+  label: string;
+  position: Position;
+  size?: Size;
+  type?: string;
+  icon?: string;
+  color?: string;
+  borderColor?: string;
+  description?: string;
+  parentContainer?: string;
+}
+
+export interface Container {
+  id: string;
+  label: string;
+  position: Position;
+  size: Size;
+  icon?: string;
+  color?: string;
+  borderColor?: string;
+  description?: string;
+}
+
+export interface Connection {
+  id: string;
+  source: string;
+  target: string;
+  label?: string;
+  type?: string;
+  animated?: boolean;
+  description?: string;
+  style?: Record<string, any>;
+}
+
+export interface DiagramData {
+  containers: Container[];
+  nodes: Node[];
+  connections: Connection[];
+  metadata?: Record<string, any>;
+}
+
+export interface ArchitectureDiagramEditorProps {
+  value?: DiagramData;
+  defaultValue?: DiagramData;
+  /**
+   * @deprecated use `defaultValue` or `value` instead
+   */
+  diagram?: DiagramData;
+  onChange?: (diagram: DiagramData) => void;
+  onNodeChange?: (nodeId: string, changes: Partial<Node>) => void;
+  onConnectionChange?: (connectionId: string, changes: Partial<Connection>) => void;
+  onSelectionChange?: (selection: { nodes: string[]; connections: string[] }) => void;
+  onError?: (error: Error) => void;
+  style?: CSSProperties;
+  className?: string;
+  mode?: 'light' | 'dark';
+  readOnly?: boolean;
+  disabled?: boolean;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "target": "es5",
+    "module": "commonjs",
+    "jsx": "react",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/types/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- update `ArchitectureDiagramEditor` to support controlled/uncontrolled usage
- expose diagram editing callbacks from `ArchitectureDiagramEditorContent`
- add new React hooks `useDiagram` and `useSelection`
- expose all components and hooks through `src/components/index.js`
- provide TypeScript type definitions
- update build scripts and types entry in `package.json`
- prevent callback loops in `ArchitectureDiagramEditorContent`
- fix missing `../types` module reference
- stop rerender loops in controlled editor by avoiding unnecessary state resets
- add tsconfig and fix type generation
- fix build output path and export compiled modules
- correct import paths for compiled output
- support legacy `diagram` prop and add `prepare` script

## Testing
- `npm run build:lib`
- `npm run build:css`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68532a231cbc8328845e0e7e3b07d649