### PR TITLE
Optimize editor rendering

### DIFF
--- a/src/components/editor/ArchitectureDiagramEditor.jsx
+++ b/src/components/editor/ArchitectureDiagramEditor.jsx
@@ -1,10 +1,22 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ReactFlowProvider } from 'reactflow';
 import ArchitectureDiagramEditorContent from './ArchitectureDiagramEditorContent';
 import 'reactflow/dist/style.css';
 import useThemeStore from '../store/themeStore';
 
-const ArchitectureDiagramEditor = ({ diagram, style = {}, className, mode = 'light', showThemeToggle = false, onToggleMini, showMiniToggle = false }) => {
+/**
+ * Main editor component used to render diagrams. Wrapped with `React.memo`
+ * to prevent unnecessary re-renders when props remain unchanged.
+ */
+const ArchitectureDiagramEditorComponent = ({
+    diagram,
+    style = {},
+    className,
+    mode = 'light',
+    showThemeToggle = false,
+    onToggleMini,
+    showMiniToggle = false,
+}) => {
     const { theme, setTheme, toggleTheme } = useThemeStore();
     const [isFullscreen, setIsFullscreen] = useState(false);
 
@@ -12,20 +24,34 @@ const ArchitectureDiagramEditor = ({ diagram, style = {}, className, mode = 'lig
         setTheme(mode);
     }, [mode, setTheme]);
 
-    const combinedStyle = { width: '100%', height: '100%', ...style };
-    const fullscreenStyle = isFullscreen
-        ? { position: 'fixed', inset: 0, width: '100vw', height: '100vh', zIndex: 1000 }
-        : {};
-    const modeClass = theme === 'dark' ? 'dark' : '';
+    const combinedStyle = useMemo(
+        () => ({ width: '100%', height: '100%', ...style }),
+        [style],
+    );
 
-    const handleToggleTheme = () => toggleTheme();
-    const toggleFullscreen = () => setIsFullscreen((prev) => !prev);
+    const fullscreenStyle = useMemo(
+        () =>
+            isFullscreen
+                ? { position: 'fixed', inset: 0, width: '100vw', height: '100vh', zIndex: 1000 }
+                : {},
+        [isFullscreen],
+    );
 
-    const containerStyle = { ...combinedStyle, ...fullscreenStyle };
+    const containerStyle = useMemo(
+        () => ({ ...combinedStyle, ...fullscreenStyle }),
+        [combinedStyle, fullscreenStyle],
+    );
+
+    const modeClass = useMemo(() => (theme === 'dark' ? 'dark' : ''), [theme]);
+
+    const handleToggleTheme = useCallback(() => toggleTheme(), [toggleTheme]);
+    const toggleFullscreen = useCallback(() => setIsFullscreen((prev) => !prev), []);
 
     return (
         <div style={containerStyle} className={`graphing ${className || ''}`}>
-            <div className={`${modeClass} w-full h-full bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 relative transition-colors`}>
+            <div
+                className={`${modeClass} w-full h-full bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 relative transition-colors`}
+            >
                 <ReactFlowProvider>
                     <ArchitectureDiagramEditorContent
                         initialDiagram={diagram}
@@ -41,5 +67,8 @@ const ArchitectureDiagramEditor = ({ diagram, style = {}, className, mode = 'lig
         </div>
     );
 };
+
+// Export a memoized version to avoid re-rendering when props are the same
+const ArchitectureDiagramEditor = React.memo(ArchitectureDiagramEditorComponent);
 
 export default ArchitectureDiagramEditor;


### PR DESCRIPTION
## Summary
- memoize ArchitectureDiagramEditor to avoid unnecessary re-renders
- use memoized styles and callbacks for efficiency

## Testing
- `npm test`
- `npm run build`
- `npm run build:lib`


------
https://chatgpt.com/codex/tasks/task_e_689519409da08328a1c318e0790b1e4e